### PR TITLE
fix compile warnings caused by missing override specifier

### DIFF
--- a/PageExtractionPlugin/src/DkPageExtractionPlugin.h
+++ b/PageExtractionPlugin/src/DkPageExtractionPlugin.h
@@ -39,8 +39,8 @@ public:
     DkPageExtractionPlugin(QObject *parent = 0);
     ~DkPageExtractionPlugin();
 
-    QImage image() const;
-    QString name() const;
+    QImage image() const override;
+    QString name() const override;
 
     QList<QAction *> createActions(QWidget *parent) override;
     QList<QAction *> pluginActions() const override;
@@ -49,8 +49,8 @@ public:
                                                     const nmc::DkSaveInfo &saveInfo,
                                                     QSharedPointer<nmc::DkBatchInfo> &batchInfo) const override;
 
-    virtual void preLoadPlugin() const {}; // is called before batch processing
-    virtual void postLoadPlugin(const QVector<QSharedPointer<nmc::DkBatchInfo>> &) const {}; // is called after batch processing
+    void preLoadPlugin() const override {}; // is called before batch processing
+    void postLoadPlugin(const QVector<QSharedPointer<nmc::DkBatchInfo>> &) const override {}; // is called after batch processing
 
     enum {
         id_crop_to_page,


### PR DESCRIPTION
avoid this
```
[ 87%] Building CXX object plugins/PageExtractionPlugin/CMakeFiles/pageExtractionPlugin.dir/pageExtractionPlugin_autogen/mocs_compilation.cpp.o
In file included from /src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/mocs_compilation.cpp:2:
In file included from /src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/UVLADIE3JM/moc_DkPageExtractionPlugin.cpp:9:
/src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/UVLADIE3JM/../../../../../ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.h:42:12: warning: 'image' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    QImage image() const;
           ^
/src/opensource/nomacs.hmueller01/ImageLounge/src/DkCore/DkPluginInterface.h:76:20: note: overridden virtual function is here
    virtual QImage image() const = 0;
                   ^
In file included from /src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/mocs_compilation.cpp:2:
In file included from /src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/UVLADIE3JM/moc_DkPageExtractionPlugin.cpp:9:
/src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/UVLADIE3JM/../../../../../ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.h:43:13: warning: 'name' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    QString name() const;
            ^
/src/opensource/nomacs.hmueller01/ImageLounge/src/DkCore/DkPluginInterface.h:150:21: note: overridden virtual function is here
    virtual QString name() const = 0; // is needed for settings
                    ^
In file included from /src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/mocs_compilation.cpp:2:
In file included from /src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/UVLADIE3JM/moc_DkPageExtractionPlugin.cpp:9:
/src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/UVLADIE3JM/../../../../../ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.h:52:18: warning: 'preLoadPlugin' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual void preLoadPlugin() const {}; // is called before batch processing
                 ^
/src/opensource/nomacs.hmueller01/ImageLounge/src/DkCore/DkPluginInterface.h:147:18: note: overridden virtual function is here
    virtual void preLoadPlugin() const = 0; // is called before batch processing
                 ^
In file included from /src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/mocs_compilation.cpp:2:
In file included from /src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/UVLADIE3JM/moc_DkPageExtractionPlugin.cpp:9:
/src/opensource/nomacs.hmueller01/build/plugins/PageExtractionPlugin/pageExtractionPlugin_autogen/UVLADIE3JM/../../../../../ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.h:53:18: warning: 'postLoadPlugin' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual void postLoadPlugin(const QVector<QSharedPointer<nmc::DkBatchInfo>> &) const {}; // is called after batch processing
                 ^
/src/opensource/nomacs.hmueller01/ImageLounge/src/DkCore/DkPluginInterface.h:148:18: note: overridden virtual function is here
    virtual void postLoadPlugin(const QVector<QSharedPointer<DkBatchInfo>> &batchInfo) const = 0; // is called after batch processing
                 ^
4 warnings generated.
[ 88%] Building CXX object plugins/PageExtractionPlugin/CMakeFiles/pageExtractionPlugin.dir/src/DkPageExtractionPlugin.cpp.o
In file included from /src/opensource/nomacs.hmueller01/ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.cpp:25:
/src/opensource/nomacs.hmueller01/ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.h:42:12: warning: 'image' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    QImage image() const;
           ^
/src/opensource/nomacs.hmueller01/ImageLounge/src/DkCore/DkPluginInterface.h:76:20: note: overridden virtual function is here
    virtual QImage image() const = 0;
                   ^
In file included from /src/opensource/nomacs.hmueller01/ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.cpp:25:
/src/opensource/nomacs.hmueller01/ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.h:43:13: warning: 'name' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    QString name() const;
            ^
/src/opensource/nomacs.hmueller01/ImageLounge/src/DkCore/DkPluginInterface.h:150:21: note: overridden virtual function is here
    virtual QString name() const = 0; // is needed for settings
                    ^
In file included from /src/opensource/nomacs.hmueller01/ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.cpp:25:
/src/opensource/nomacs.hmueller01/ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.h:52:18: warning: 'preLoadPlugin' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual void preLoadPlugin() const {}; // is called before batch processing
                 ^
/src/opensource/nomacs.hmueller01/ImageLounge/src/DkCore/DkPluginInterface.h:147:18: note: overridden virtual function is here
    virtual void preLoadPlugin() const = 0; // is called before batch processing
                 ^
In file included from /src/opensource/nomacs.hmueller01/ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.cpp:25:
/src/opensource/nomacs.hmueller01/ImageLounge/plugins/PageExtractionPlugin/src/DkPageExtractionPlugin.h:53:18: warning: 'postLoadPlugin' overrides a member function but is not marked 'override' [-Winconsistent-missing-override]
    virtual void postLoadPlugin(const QVector<QSharedPointer<nmc::DkBatchInfo>> &) const {}; // is called after batch processing
                 ^
/src/opensource/nomacs.hmueller01/ImageLounge/src/DkCore/DkPluginInterface.h:148:18: note: overridden virtual function is here
    virtual void postLoadPlugin(const QVector<QSharedPointer<DkBatchInfo>> &batchInfo) const = 0; // is called after batch processing
                 ^
4 warnings generated.
[ 88%] Linking CXX shared library ../libpageExtractionPlugin.dylib


```